### PR TITLE
Disable react/jsx-one-expression-per-line

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,8 +28,10 @@
             "imports": "always-multiline",
             "exports": "always-multiline"
         }],
+        "jsx-a11y/anchor-is-valid": "off",
+
         "react/prop-types": "off",
         "react/jsx-filename-extension": "off",
-        "jsx-a11y/anchor-is-valid": "off"
+        "react/jsx-one-expression-per-line": "off"
     }
 }


### PR DESCRIPTION
I would disable react/jsx-one-expression-per-line because this often creates more unreadable code.
Example: 

**Before:**
![image](https://user-images.githubusercontent.com/1827410/55468032-d2ea3b00-5602-11e9-89aa-c1bf38c83254.png)

**After:**
![image](https://user-images.githubusercontent.com/1827410/55468076-e9909200-5602-11e9-98fe-9633564f6e33.png)

Or when we use this rule we should try to wrap more inside spans or divs. This would add unnecessary dom elements but will keep the code readable